### PR TITLE
Better error messages when running modules

### DIFF
--- a/compiler-cli/src/run.rs
+++ b/compiler-cli/src/run.rs
@@ -4,6 +4,7 @@ use gleam_core::{
     error::Error,
     io::{CommandExecutor, Stdio},
     paths::ProjectPaths,
+    type_::ModuleFunction,
 };
 use lazy_static::lazy_static;
 use smol_str::SmolStr;
@@ -32,20 +33,6 @@ pub fn command(
         if !is_gleam_module(mod_path) {
             return Err(Error::InvalidModuleName {
                 module: mod_path.to_owned(),
-            });
-        }
-
-        if mod_path.starts_with("src/") {
-            return Err(Error::InvalidModulePrefix {
-                module: mod_path.strip_prefix("src/").unwrap().to_string(),
-                prefix: "src/".to_string(),
-            });
-        }
-
-        if mod_path.starts_with("test/") {
-            return Err(Error::InvalidModulePrefix {
-                module: mod_path.strip_prefix("test/").unwrap().to_string(),
-                prefix: "test/".to_string(),
             });
         }
     };
@@ -84,7 +71,7 @@ pub fn command(
     )?;
 
     // A module can not be run if it does not exist or does not have a public main function.
-    let main_function = built.get_main_function(&SmolStr::from(module.to_owned()))?;
+    let main_function = get_or_suggest_main_function(built, &module)?;
 
     // Don't exit on ctrl+c as it is used by child erlang shell
     ctrlc::set_handler(move || {}).expect("Error setting Ctrl-C handler");
@@ -279,6 +266,38 @@ fn is_gleam_module(module: &str) -> bool {
     }
 
     RE.is_match(module)
+}
+
+/// If provided module is not executable, suggest a possible valid module.
+fn get_or_suggest_main_function(
+    built: gleam_core::build::Built,
+    module: &String,
+) -> Result<ModuleFunction, Error> {
+    match built.get_main_function(&SmolStr::from(module.to_owned())) {
+        Ok(main_fn) => Ok(main_fn),
+        Err(err) => {
+            // Suggest possible modules that may have been intended
+            if let Some(mod_path) = module.strip_prefix("src/") {
+                if let Ok(_) = built.get_main_function(&SmolStr::from(mod_path.to_owned())) {
+                    return Err(Error::InvalidModulePrefix {
+                        module: mod_path.to_string(),
+                        prefix: "src/".to_string(),
+                    });
+                }
+            }
+
+            if let Some(mod_path) = module.strip_prefix("test/") {
+                if let Ok(_) = built.get_main_function(&SmolStr::from(mod_path.to_owned())) {
+                    return Err(Error::InvalidModulePrefix {
+                        module: mod_path.to_string(),
+                        prefix: "test/".to_string(),
+                    });
+                }
+            }
+
+            Err(err)
+        }
+    }
 }
 
 #[test]

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -454,13 +454,14 @@ forward slash and must not end with a slash."
                 }
             }
 
-            Error::ModuleDoesNotExist { module,  } => Diagnostic {
+            Error::ModuleDoesNotExist { module } => Diagnostic {
                 title: "Module does not exist".into(),
-                text: format!("No module was found with the name `{module}`."),
+                text: format!("Module `{module}` was not found"),
                 level: Level::Error,
                 location: None,
                 hint: Some(
-                    format!("No module was found with the name `{module}`.")
+                    format!("Try creating the file `src/{}.gleam`.",
+                    module)
                 ),
             },
 

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -439,15 +439,29 @@ forward slash and must not end with a slash."
                 hint: None,
             },
 
-            Error::ModuleDoesNotExist { module } => Diagnostic {
-                title: "Module does not exist".into(),
-                text: format!("Module `{module}` was not found"),
-                level: Level::Error,
-                location: None,
-                hint: Some(
-                    format!("Try creating the file `src/{}.gleam`.",
-                    module)
-                ),
+            Error::ModuleDoesNotExist { module } => {
+                let prefix = module.split("/").next();
+
+                let suggested_file = match prefix {
+                    Some("src") => &module[4..],
+                    Some("test") => &module[5..],
+                    _ => module,
+                };
+
+                let text = match prefix {
+                    Some("src") | Some("test") => format!("You are calling a module with `{prefix}`.\nOnly modules within /src and /test are executable.", prefix = prefix.unwrap()),
+                    _ => format!("No module was found with the name `{module}`."),
+                };
+
+                Diagnostic {
+                    title: "Module does not exist".into(),
+                    text,
+                    level: Level::Error,
+                    location: None,
+                    hint: Some(
+                        format!("Did you mean `{suggested_file}`.")
+                    ),
+                }
             },
 
             Error::ModuleDoesNotHaveMainFunction { module } => Diagnostic {

--- a/test/running_modules/run_tests.sh
+++ b/test/running_modules/run_tests.sh
@@ -17,10 +17,10 @@ should_succeed() {
 should_fail() {
     echo
     echo Running: "$@"
-    
+
     EXIT_CODE=0
     cargo run -- $@ > /dev/null 2>&1 || EXIT_CODE=$?
-    
+
     if [ $EXIT_CODE -eq 0 ]
     then
         echo ERROR: Command should have failed
@@ -52,6 +52,9 @@ should_succeed run --module gleeunit --target javascript --runtime deno
 
 # Unknown module
 should_fail run --module doesnt_exist
+
+# Unknown module should only belong as a package or in src/ and test/
+should_fail run --module src/doesnt_exist
 
 # No main function
 should_fail run --module module/no_main_function


### PR DESCRIPTION
Resolves the original issue https://github.com/gleam-lang/gleam/issues/2155

## Changes

I added a new error enum that is specific to calling modules with the extra `src/` and `test/` prefixes. The issue was that I attempted to execute modules with `src/x/y/z` instead of just `x/y/z`. It's also not clear that `src/` and `test/` are special directories. The new error message teaches users this.

I did not complete the additional work of suggesting an in-project module or 3rd party module by checking the dependency graph.

The results

```
error: Module does not exist

You are calling a module with `src/`.
Only files within src/ and test/ are valid modules.
Hint: Try running `okay/yo`.
```